### PR TITLE
Update CMake version requirements so recent versions know it works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.6...3.20)
 project (Wmi)
 set (CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -c -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64")


### PR DESCRIPTION
This indicates to CMake that it works with version 2.6 and up, but
has been tested with 3.20 as well. This fixes the deprecation warnings
about CMake < 2.18.0 support being dropped in the near future.