### PR TITLE
added methods to retrieve only certain columns from table

### DIFF
--- a/include/wmi.hpp
+++ b/include/wmi.hpp
@@ -35,10 +35,27 @@ namespace Wmi
 	}
 
 	template <class WmiClass>
+	inline void retrieveWmi(WmiClass &out, std::string columns)
+	{
+		WmiResult result;
+		const std::string q = std::string("Select ") + columns + std::string(" From ") + WmiClass::getWmiClassName();
+		query(q, result);
+		out.setProperties(result, 0);
+	}
+
+	template <class WmiClass>
 	inline WmiClass retrieveWmi()
 	{
 		WmiClass temp;
 		retrieveWmi(temp);
+		return temp;
+	}
+
+	template <class WmiClass>
+	inline WmiClass retrieveWmi(std::string columns)
+	{
+		WmiClass temp;
+		retrieveWmi(temp, columns);
 		return temp;
 	}
 
@@ -59,10 +76,35 @@ namespace Wmi
 	}
 
 	template <class WmiClass>
+	inline void retrieveAllWmi(std::vector<WmiClass> &out, std::string columns)
+	{
+		WmiResult result;
+		const std::string q = std::string("Select ") + columns + std::string(" From ") + WmiClass::getWmiClassName();
+		query(q, result);
+
+		out.clear();
+		for(std::size_t index = 0; index < result.size(); ++index)
+		{
+			WmiClass temp;
+			temp.setProperties(result, index);
+			out.push_back(std::move(temp));
+		}
+	}
+
+	template <class WmiClass>
 	inline std::vector<WmiClass> retrieveAllWmi()
 	{
 		std::vector<WmiClass> ret;
 		retrieveAllWmi(ret);
+
+		return ret;
+	}
+
+	template <class WmiClass>
+	inline std::vector<WmiClass> retrieveAllWmi(std::string columns)
+	{
+		std::vector<WmiClass> ret;
+		retrieveAllWmi(ret, columns);
 
 		return ret;
 	}

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -32,8 +32,15 @@ int main(int /*argc*/, char */*args*/[])
 		cout<<endl;
                 cout << "Machine Id:" << liscense.ClientMachineID << " Kmsid:" << liscense.KeyManagementServiceProductKeyID << std::endl;
                 cout<<"Installed services:"<<endl;
-		
+
+		// gets all rows and all columns
 		for(const Win32_Service &service : retrieveAllWmi<Win32_Service>())
+		{
+			cout<<service.Caption<<" started:"<<service.Started<<" state:"<<service.State<<  endl;
+		}
+		
+		// gets all rows and only specified columns(better performance)
+		for(const Win32_Service &service : retrieveAllWmi<Win32_Service>("Caption,Started,State"))
 		{
 			cout<<service.Caption<<" started:"<<service.Started<<" state:"<<service.State<<  endl;
 		}


### PR DESCRIPTION
added methods to query only specific columns from a table. This can drastically increase performance when working with large tables. In my case, when querying the "SoftwareLicensingProduct" table my query time went from 40 seconds to only 3.