### PR TITLE
Fixing cross-compile errors caused by 'case' mismatches in some

### DIFF
--- a/diaa_sami_comsupp/diaa_sami_comsupp.cpp
+++ b/diaa_sami_comsupp/diaa_sami_comsupp.cpp
@@ -1,8 +1,8 @@
 // Written by: Diaa Sami
 
-#include <Windows.h>
+#include <windows.h>
 #include <stdlib.h>
-#include <StrSafe.h>
+#include <strsafe.h>
 
 void __stdcall _com_issue_error(HRESULT hr)
 {

--- a/src/wmi.cpp
+++ b/src/wmi.cpp
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <comdef.h>
 #include <functional>
-#include <WbemCli.h>
+#include <wbemcli.h>
 #include <windows.h>
 
 #include <wmi.hpp>


### PR DESCRIPTION
I'm working on a rpm package of wmi for installation in cross-compiler environments (https://build.opensuse.org/package/show/home:PerryWerneck:mingw/mingw64-libwmi++). During this I got some build errors caused by case mismatch on some file names.
